### PR TITLE
Dummy PR for review

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,44 @@
+{
+  "nodes": {
+    "irmaseal-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627548173,
+        "narHash": "sha256-wvdoFxcAQIgNMvap+fGHAs6caphj+LbTVUCdE5/gbZs=",
+        "owner": "Wassasin",
+        "repo": "irmaseal",
+        "rev": "3aaec4e4018d356850b0469df6aeb5765f3756df",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Wassasin",
+        "repo": "irmaseal",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1630424636,
+        "narHash": "sha256-TKzxyJ1r5zflL0yewsA3tHq/2A64eNm5hkgO/nhwbFg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4b7e51865e44d3afc564e3a3111af12be1003251",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-21.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "irmaseal-src": "irmaseal-src",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,65 @@
+{
+  description = "Shadysim";
+
+  inputs = {
+
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-21.05";
+
+    irmaseal-src = {
+      url = "github:Wassasin/irmaseal";
+      flake = false;
+    };
+
+  };
+
+
+  outputs =
+    { self
+    , nixpkgs
+    , irmaseal-src
+    , ...
+    }:
+    let
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+
+      nixpkgsFor = forAllSystems (system:
+        import nixpkgs {
+          inherit system;
+          overlays = [ self.overlay ];
+        }
+      );
+
+    in
+    {
+
+      overlay = final: prev: rec {
+
+        irmaseal-cli = with final; callPackage ./pkgs/irmaseal-cli.nix {
+          inherit irmaseal-src;
+        };
+
+        irmaseal-pkg = with final; callPackage ./pkgs/irmaseal-pkg.nix {
+          inherit irmaseal-src;
+        };
+
+      };
+
+      nixosModules.irmaseal-pkg = {
+        imports = [ ./modules/irmaseal-pkg-server.nix ];
+        nixpkgs.overlays = [ self.overlay ];
+      };
+
+      packages = forAllSystems (system: {
+        inherit (nixpkgsFor.${system})
+          irmaseal-cli
+          irmaseal-pkg;
+      });
+
+
+      defaultPackage =
+        forAllSystems (system: self.packages.${system}.irmaseal-cli);
+
+    };
+
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Shadysim";
+  description = "IRMAseal - identity based encryption service";
 
   inputs = {
 

--- a/modules/irmaseal-pkg-server.nix
+++ b/modules/irmaseal-pkg-server.nix
@@ -24,7 +24,7 @@ in
 
     host = mkOption {
       type = types.str;
-      default = "0.0.0.0";
+      default = "127.0.0.1";
       description = ''
         Host to bind this service to
       '';
@@ -71,15 +71,19 @@ in
     systemd.services.irmaseal-pkg = {
       description = "IRMAseal PKG HTTP server";
       wantedBy = [ "multi-user.target" ];
-      serviceConfig.Restart = "always";
-      script = ''
-        ${cfg.package}/bin/irmaseal-pkg server \
-          --host '${cfg.host}' \
-          --irma '${cfg.irma}' \
-          --port ${toString cfg.port} \
-          --public '${cfg.publicKeyPath}' \
-          --secret '${cfg.secretKeyPath}'
-      '';
+      serviceConfig = {
+        ExecStart = ''
+          ${cfg.package}/bin/irmaseal-pkg server \
+            --host '${cfg.host}' \
+            --irma '${cfg.irma}' \
+            --port ${toString cfg.port} \
+            --public '${cfg.publicKeyPath}' \
+            --secret '${cfg.secretKeyPath}'
+        '';
+        Restart = "always";
+        DynamicUser = true;
+        PrivateTmp = true;
+      };
     };
 
   };

--- a/modules/irmaseal-pkg-server.nix
+++ b/modules/irmaseal-pkg-server.nix
@@ -1,0 +1,88 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.services.irmaseal-pkg;
+in
+{
+
+  options.services.irmaseal-pkg = {
+
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        If enabled, NixOS will periodically update the database of
+        files used by the locate command.
+      '';
+    };
+
+    package = mkOption {
+      type = types.path;
+      default = pkgs.irmaseal-pkg;
+      description = "The IRMAseal PKG package to use";
+    };
+
+    host = mkOption {
+      type = types.str;
+      default = "0.0.0.0";
+      description = ''
+        Host to bind this service to
+      '';
+    };
+
+    irma = mkOption {
+      type = types.str;
+      default = "https://irma-noauth.demo.sarif.nl";
+      description = ''
+        URL of the IRMA go server to use for authentication
+      '';
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 8087;
+      description = ''
+        TCP port to bind this service to
+      '';
+    };
+
+    publicKeyPath = mkOption {
+      type = types.path;
+      default = ./pkg.pub;
+      description = ''
+        Path to the public key
+      '';
+    };
+
+    secretKeyPath = mkOption {
+      type = types.path;
+      default = ./pkg.sec;
+      description = ''
+        Path to the private key
+      '';
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.irmaseal-pkg = {
+      description = "IRMAseal PKG HTTP server";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig.Restart = "always";
+      script = ''
+        ${cfg.package}/bin/irmaseal-pkg server \
+          --host '${cfg.host}' \
+          --irma '${cfg.irma}' \
+          --port ${toString cfg.port} \
+          --public '${cfg.publicKeyPath}' \
+          --secret '${cfg.secretKeyPath}'
+      '';
+    };
+
+  };
+
+}

--- a/modules/irmaseal-pkg-server.nix
+++ b/modules/irmaseal-pkg-server.nix
@@ -12,15 +12,14 @@ in
       type = types.bool;
       default = false;
       description = ''
-        If enabled, NixOS will periodically update the database of
-        files used by the locate command.
+        This option enables the IRMAseal-PKG server.
       '';
     };
 
     package = mkOption {
       type = types.path;
       default = pkgs.irmaseal-pkg;
-      description = "The IRMAseal PKG package to use";
+      description = "The IRMAseal-PKG package to use";
     };
 
     host = mkOption {

--- a/modules/irmaseal-pkg-server.nix
+++ b/modules/irmaseal-pkg-server.nix
@@ -83,6 +83,7 @@ in
         Restart = "always";
         DynamicUser = true;
         PrivateTmp = true;
+        ReadOnlyPaths = "${cfg.publicKeyPath} ${cfg.secretKeyPath}";
       };
     };
 

--- a/pkgs/irmaseal-cli.nix
+++ b/pkgs/irmaseal-cli.nix
@@ -1,0 +1,19 @@
+{ stdenv
+, lib
+, rustPlatform
+, irmaseal-src
+}:
+let
+  version = "0.1.4";
+in
+rustPlatform.buildRustPackage {
+  pname = "irmaseal-cli";
+  inherit version;
+
+  buildInputs = [ ];
+
+  src = "${irmaseal-src}/irmaseal-cli";
+
+  cargoSha256 = "ieIxRUDgZ9Lyg5pNtIO/2zXYS+GfwWRZ5ARiSbk9X8E=";
+
+}

--- a/pkgs/irmaseal-cli.nix
+++ b/pkgs/irmaseal-cli.nix
@@ -9,11 +9,6 @@ in
 rustPlatform.buildRustPackage {
   pname = "irmaseal-cli";
   inherit version;
-
-  buildInputs = [ ];
-
   src = "${irmaseal-src}/irmaseal-cli";
-
   cargoSha256 = "ieIxRUDgZ9Lyg5pNtIO/2zXYS+GfwWRZ5ARiSbk9X8E=";
-
 }

--- a/pkgs/irmaseal-pkg.nix
+++ b/pkgs/irmaseal-pkg.nix
@@ -1,0 +1,19 @@
+{ stdenv
+, lib
+, rustPlatform
+, irmaseal-src
+}:
+let
+  version = "0.1.2";
+in
+rustPlatform.buildRustPackage {
+  pname = "irmaseal-pkg";
+  inherit version;
+
+  buildInputs = [ ];
+
+  src = "${irmaseal-src}/irmaseal-pkg";
+
+  cargoSha256 = "y+fL4ERkEcuIAgNBFHNrWBBwoZ4VfGpqpHFqEJDymkg=";
+
+}

--- a/pkgs/irmaseal-pkg.nix
+++ b/pkgs/irmaseal-pkg.nix
@@ -9,11 +9,6 @@ in
 rustPlatform.buildRustPackage {
   pname = "irmaseal-pkg";
   inherit version;
-
-  buildInputs = [ ];
-
   src = "${irmaseal-src}/irmaseal-pkg";
-
   cargoSha256 = "y+fL4ERkEcuIAgNBFHNrWBBwoZ4VfGpqpHFqEJDymkg=";
-
 }

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,58 @@
+## IRMAseal
+
+This flake packages the [IRMAseal]() set of packages.
+Included are:
+
+ - `irmaseal-cli`
+ - `irmaseal-pkg`
+
+### IRMAseal-cli
+
+Command-line application that serves all IRMAseal
+operations, including IRMA attribute disclosure proofs. This
+flake provides `irmaseal-cli` as a package:
+
+```
+nix build github:ngi-nix/irmaseal#irmaseal-cli
+
+./result/bin/irmaseal-cli -V
+irmaseal-cli 0.1
+```
+
+### IRMAseal-pkg
+
+The *Private Key Generator*, an HTTP REST service that
+receives attribute disclosure proofs and yields the
+corresponding user secret key. This flake provides
+IRMAseal-pkg as a package as well as a module. 
+
+To use IRMAseal-pkg as a standalone package:
+```
+nix build github:ngi-nix/irmaseal#irmaseal-pkg
+
+# the standalone package can be used to generate keys
+./result/bin/irmaseal-pkg generate
+Written ./pkg.pub and ./pkg.sec
+
+# it can also be used to run the HTTP service
+./result/bin/irmaseal-pkg server
+```
+
+To use IRMAseal-pkg as a module:
+
+```
+# in /etc/nixos/configuration.nix
+{
+  imports = [
+    (builtins.getFlake "github:ngi-nix/irmaseal").nixosModules.irmaseal-pkg
+  ];
+  
+  services.irmaseal-pkg.enable = true;
+}
+```
+
+## Future work
+
+Code belonging to IRMAseal clients for mailclient are not
+are still a work in progress and should be included in this
+flake when ready.

--- a/readme.md
+++ b/readme.md
@@ -15,8 +15,22 @@ flake provides `irmaseal-cli` as a package:
 ```
 nix build github:ngi-nix/irmaseal#irmaseal-cli
 
-./result/bin/irmaseal-cli -V
+./result/bin/irmaseal-cli -h
 irmaseal-cli 0.1
+Wouter Geraedts <w.geraedts@sarif.nl>
+Command line interface for IRMAseal, an Identity Based Encryption standard.
+
+USAGE:
+    irmaseal-cli [SUBCOMMAND]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    decrypt    decrypt a file
+    encrypt    encrypt a file
+    help       Prints this message or the help of the given subcommand(s)
 ```
 
 ### IRMAseal-pkg
@@ -30,6 +44,23 @@ To use IRMAseal-pkg as a standalone package:
 ```
 nix build github:ngi-nix/irmaseal#irmaseal-pkg
 
+./result/bin/irmaseal-pkg -h
+irmaseal-pkg 0.1
+Wouter Geraedts <w.geraedts@sarif.nl>
+Private Key Generator (PKG) for IRMAseal, an Identity Based Encryption standard.
+
+USAGE:
+    irmaseal-pkg [SUBCOMMAND]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    generate    generate a global public/private keypair
+    help        Prints this message or the help of the given subcommand(s)
+    server      run the IRMAseal PKG HTTP server
+
 # the standalone package can be used to generate keys
 ./result/bin/irmaseal-pkg generate
 Written ./pkg.pub and ./pkg.sec
@@ -38,7 +69,8 @@ Written ./pkg.pub and ./pkg.sec
 ./result/bin/irmaseal-pkg server
 ```
 
-To use IRMAseal-pkg as a module:
+To use IRMAseal-pkg as a module, first generate keys with
+`irmaseal-pkg generate`, and then enable the NixOS module:
 
 ```
 # in /etc/nixos/configuration.nix
@@ -47,7 +79,14 @@ To use IRMAseal-pkg as a module:
     (builtins.getFlake "github:ngi-nix/irmaseal").nixosModules.irmaseal-pkg
   ];
   
-  services.irmaseal-pkg.enable = true;
+  services.irmaseal-pkg = {
+    enable = true;
+    
+    # these are keys generated via `irmaseal-pkg generate`
+    publicKeyPath = /path/to/pkg.pub;
+    secretKeyPath = /path/to/pkg.sec;
+  };
+
 }
 ```
 


### PR DESCRIPTION
Adds two packages
 - irmaseal-cli
 - irmaseal-pkg (private key generator)

IRMAseal-pkg can be used as a tool to generate keys, and also be run as a server with `./irmaseal-pkg server`, so this flake provides a module to run the server.